### PR TITLE
Add f-ext? predicate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-absolute?](#f-absolute-path) `(path)`
 * [f-relative?](#f-relative-path) `(path)`
 * [f-root?](#f-root-path) `(path)`
+* [f-ext?](#f-ext-path-ext) `(path ext)`
 
 ### Stats
 
@@ -287,6 +288,20 @@ Return t if PATH is root directory, false otherwise.
 ```lisp
 (f-root? "/") ;; => t
 (f-root? "/not/root") ;; => nil
+```
+
+### f-ext? `(path ext)`
+
+Return t if extension of PATH is EXT, false otherwise.
+
+If EXT is nil or omitted, return t if PATH has any extension,
+false otherwise.
+
+```lisp
+(f-ext? "path/to/file.el" "el") ;; => t
+(f-ext? "path/to/file.el" "txt") ;; => nil
+(f-ext? "path/to/file.el") ;; => t
+(f-ext? "path/to/file") ;; => nil
 ```
 
 ### f-size `(path)`

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -48,6 +48,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-absolute?](#f-absolute-path) `(path)`
 * [f-relative?](#f-relative-path) `(path)`
 * [f-root?](#f-root-path) `(path)`
+* [f-ext?](#f-ext-path-ext) `(path ext)`
 
 ### Stats
 
@@ -285,6 +286,17 @@ Alias: `f-dir?`
 ```lisp
 (f-root? "/") ;; => t
 (f-root? "/not/root") ;; => nil
+```
+
+### f-ext? `(path ext)`
+
+{{f-ext?}}
+
+```lisp
+(f-ext? "path/to/file.el" "el") ;; => t
+(f-ext? "path/to/file.el" "txt") ;; => nil
+(f-ext? "path/to/file.el") ;; => t
+(f-ext? "path/to/file") ;; => nil
 ```
 
 ### f-size `(path)`

--- a/f.el
+++ b/f.el
@@ -154,6 +154,15 @@ If FORCE is t, a directory will be deleted recursively."
   "Return t if PATH is root directory, false otherwise."
   (equal path (f-parent path)))
 
+(defun f-ext? (path &optional ext)
+  "Return t if extension of PATH is EXT, false otherwise.
+
+If EXT is nil or omitted, return t if PATH has any extension,
+false otherwise."
+  (if ext
+      (string= (f-ext path) ext)
+    (not (eq (f-ext path) nil))))
+
 (defun f-size (path)
   "Return size of PATH.
 

--- a/test/f-predicates-test.el
+++ b/test/f-predicates-test.el
@@ -101,3 +101,23 @@
 
 (ert-deftest f-root?-test/is-not-root ()
   (should-not (f-root? "/not/root")))
+
+(ert-deftest f-ext?-test/ext-does-match ()
+  (with-sandbox
+   (f-write "foo.el")
+   (should (f-ext? "foo.el" "el"))))
+
+(ert-deftest f-ext?-test/ext-does-not-match ()
+  (with-sandbox
+   (f-write "foo.el")
+   (should-not (f-ext? "foo.el" "txt"))))
+
+(ert-deftest f-ext?-test/with-ext ()
+  (with-sandbox
+   (f-write "foo.el")
+   (should (f-ext? "foo.el"))))
+
+(ert-deftest f-ext?-test/without-ext ()
+  (with-sandbox
+   (f-write "foo")
+   (should-not (f-ext? "foo"))))


### PR DESCRIPTION
I periodically need to check the extension of a file in a mode hook to see if I should further enhance the mode (eg, skip [tagedit](https://github.com/magnars/tagedit) for some file types that just don't jive with it too well).

This function makes that a bit prettier.

Nice library, btw.
