### PR TITLE
Support lists as first argument to f-expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,13 @@ Join ARGS to a single path.
 
 Expand PATH relative to DIR (or `default-directory').
 
+If PATH is a list, it will first be run through `f-join'.
+
 ```lisp
 (f-expand "name") ;; => "/default/directory/name"
 (f-expand "name" "other/directory") ;; => "other/directory/name"
+(f-expand '("nested" "path")) ;; => "/default/directory/nested/path"
+(f-expand '("nested" "path") "other/directory") ;; => "other/directory/nested/path"
 ```
 
 ### f-filename `(path)`

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -80,6 +80,8 @@ Or you can just dump `f.el` in your load path somewhere.
 ```lisp
 (f-expand "name") ;; => "/default/directory/name"
 (f-expand "name" "other/directory") ;; => "other/directory/name"
+(f-expand '("nested" "path")) ;; => "/default/directory/nested/path"
+(f-expand '("nested" "path") "other/directory") ;; => "other/directory/nested/path"
 ```
 
 ### f-filename `(path)`

--- a/f.el
+++ b/f.el
@@ -43,8 +43,11 @@
     (if relative (f-relative path) path)))
 
 (defun f-expand (path &optional dir)
-  "Expand PATH relative to DIR (or `default-directory')."
-  (directory-file-name (expand-file-name path dir)))
+  "Expand PATH relative to DIR (or `default-directory').
+
+If PATH is a list, it will first be run through `f-join'."
+  (let ((path (if (listp path) (apply 'f-join path) path)))
+    (directory-file-name (expand-file-name path dir))))
 
 (defun f-filename (path)
   "Return the name of PATH."

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -18,6 +18,14 @@
   (with-default-directory
    (should (equal (f-expand "foo" "/other") "/other/foo"))))
 
+(ert-deftest f-expand-test/with-list ()
+  (with-default-directory
+   (should (equal (f-expand '("foo" "bar")) "/default/directory/foo/bar"))))
+
+(ert-deftest f-expand-test/with-list-and-dir ()
+  (with-default-directory
+   (should (equal (f-expand '("foo" "bar") "/other") "/other/foo/bar"))))
+
 (ert-deftest f-filename-test/relative ()
   (should (equal (f-filename "path/to/file") "file")))
 


### PR DESCRIPTION
I found myself writing `(f-expand (f-join some-list))` a number of times, and thought this might be a reasonable addition to the `f-expand` interface. I'm not sure how you'll feel about overloading `path` argument. It seems intuitive enough, though.
