### PR TITLE
Read/write files with proper coding conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-relative](#f-relative-path-optional-file) `(path &optional file)`
 * [f-abbrev](#f-abbrev-path) `(path)`
 * [f-canonical](#f-canonical-path) `(path)`
+* [f-this-file](#f-this-file) `()`
+
+### I/O
+
+* [f-read-bytes](#f-read-bytes-path) `(path)`
+* [f-write-bytes](#f-write-bytes-path) `(path)`
+* [f-read-text](#f-read-text-path-optional-coding) `(path &optional coding)`
+* [f-write-text](#f-write-text)`(text coding path)`
 
 ### Destructive
 
-* [f-write](#f-write-path-optional-content) `(path &optional content)`
 * [f-mkdir](#f-mkdir-rest-dirs) `(&rest dirs)`
 * [f-delete](#f-delete-path-optional-force) `(path &optional force)`
 * [f-symlink](#f-symlink-source-path) `(source path)`
@@ -59,7 +66,6 @@ Or you can just dump `f.el` in your load path somewhere.
 
 ### Misc
 
-* [f-read](#f-read-path) `(path)`
 * [f-glob](#f-glob-pattern-optional-path) `(pattern &optional path)`
 * [f-entries](#f-entries-path-optional-fn-recursive) `(path &optional fn recursive)`
 * [f-directories](#f-directories-path-optional-fn-recursive) `(path &optional fn recursive)`
@@ -162,13 +168,55 @@ Return the canonical name of PATH.
 (f-canonical "/link/to/file") ;; => /path/to/real/file
 ```
 
-### f-write `(path &optional content)`
+### f-this-file `()`
 
-Write CONTENT or nothing to PATH. If no content, just create file.
+Return path to this file.
 
 ```lisp
-(f-write "path/to/file.txt")
-(f-write "path/to/file.txt" "some-content")
+(f-this-file) ;; => /path/to/this/file
+```
+
+### f-read-bytes `(path)`
+
+Write binary DATA to PATH.
+
+DATA is a unibyte string.  PATH is a file name to write to.
+
+```lisp
+(f-read-bytes "path/to/binary/data")
+```
+
+### f-write-bytes `(path)`
+
+{Write binary DATA to PATH.
+
+DATA is a unibyte string.  PATH is a file name to write to.}
+
+```lisp
+(f-write-bytes "path/to/binary/data" (unibyte-string 72 101 108 108 111 32 119 111 114 108 100))
+```
+
+### f-read-text `(path &optional coding)`
+
+Read text with PATH, using CODING.
+
+CODING defaults to `prefer-utf-8'.
+
+Return the decoded text as multibyte string.
+
+```lisp
+(f-read-text "path/to/file.txt" 'utf-8)
+```
+
+### f-write-text `(text coding path)`
+
+Write TEXT with CODING to PATH.
+
+TEXT is a multibyte string.  CODING is a coding system to encode
+TEXT with.  PATH is a file name to write to.
+
+```lisp
+(f-write-text "Hello world" 'utf-8 "path/to/file.txt")
 ```
 
 ### f-mkdir `(&rest dirs)`
@@ -346,14 +394,6 @@ directory, return sum of all files in PATH.
 ```lisp
 (f-size "path/to/file.txt")
 (f-size "path/to/dir")
-```
-
-### f-read `(path)`
-
-Return content of PATH.
-
-```lisp
-(f-read "path/to/file.txt")
 ```
 
 ### f-glob `(pattern &optional path)`

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -30,9 +30,15 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-canonical](#f-canonical-path) `(path)`
 * [f-this-file](#f-this-file) `()`
 
+### I/O
+
+* [f-read-bytes](#f-read-bytes-path) `(path)`
+* [f-write-bytes](#f-write-bytes-path) `(path)`
+* [f-read-text](#f-read-text-path-optional-coding) `(path &optional coding)`
+* [f-write-text](#f-write-text)`(text coding path)`
+
 ### Destructive
 
-* [f-write](#f-write-path-optional-content) `(path &optional content)`
 * [f-mkdir](#f-mkdir-rest-dirs) `(&rest dirs)`
 * [f-delete](#f-delete-path-optional-force) `(path &optional force)`
 * [f-symlink](#f-symlink-source-path) `(source path)`
@@ -60,7 +66,6 @@ Or you can just dump `f.el` in your load path somewhere.
 
 ### Misc
 
-* [f-read](#f-read-path) `(path)`
 * [f-glob](#f-glob-pattern-optional-path) `(pattern &optional path)`
 * [f-entries](#f-entries-path-optional-fn-recursive) `(path &optional fn recursive)`
 * [f-directories](#f-directories-path-optional-fn-recursive) `(path &optional fn recursive)`
@@ -171,13 +176,36 @@ Alias: `f-short`
 (f-this-file) ;; => /path/to/this/file
 ```
 
-### f-write `(path &optional content)`
+### f-read-bytes `(path)`
 
-{{f-write}}
+{{f-write-bytes}}
 
 ```lisp
-(f-write "path/to/file.txt")
-(f-write "path/to/file.txt" "some-content")
+(f-read-bytes "path/to/binary/data")
+```
+
+### f-write-bytes `(path)`
+
+{{{f-write-bytes}}}
+
+```lisp
+(f-write-bytes "path/to/binary/data" (unibyte-string 72 101 108 108 111 32 119 111 114 108 100))
+```
+
+### f-read-text `(path &optional coding)`
+
+{{f-read-text}}
+
+```lisp
+(f-read-text "path/to/file.txt" 'utf-8)
+```
+
+### f-write-text `(text coding path)`
+
+{{f-write-text}}
+
+```lisp
+(f-write-text "Hello world" 'utf-8 "path/to/file.txt")
 ```
 
 ### f-mkdir `(&rest dirs)`
@@ -347,14 +375,6 @@ Alias: `f-equal?`
 ```lisp
 (f-size "path/to/file.txt")
 (f-size "path/to/dir")
-```
-
-### f-read `(path)`
-
-{{f-read}}
-
-```lisp
-(f-read "path/to/file.txt")
 ```
 
 ### f-glob `(pattern &optional path)`

--- a/test/f-destructive-test.el
+++ b/test/f-destructive-test.el
@@ -1,34 +1,3 @@
-(ert-deftest f-write-test/no-content-relative-path ()
-  (with-sandbox
-   (f-write "foo.txt")
-   (should-exist "foo.txt")))
-
-(ert-deftest f-write-test/no-content-absolute-path ()
-  (with-sandbox
-   (let* ((dirname (expand-file-name "bar" f-sandbox-path))
-          (filename (expand-file-name "foo.txt" dirname)))
-     (make-directory dirname)
-     (f-write filename)
-     (should-exist "bar/foo.txt"))))
-
-(ert-deftest f-write-test/with-content ()
-  (with-sandbox
-   (f-write "foo.txt" "FOO")
-   (should-exist "foo.txt" "FOO")))
-
-(ert-deftest f-write-test/override ()
-  (with-sandbox
-   (f-write "foo.txt" "FOO")
-   (f-write "foo.txt" "BAR")
-   (should-exist "foo.txt" "BAR")))
-
-(ert-deftest f-write-test/append ()
-  (with-sandbox
-   (f-write "foo.txt" "FOO")
-   (should-exist "foo.txt" "FOO")
-   (f-write "foo.txt" "BAR" 'append)
-   (should-exist "foo.txt" "FOOBAR")))
-
 (ert-deftest f-mkdir-test/single-level ()
   (with-sandbox
    (f-mkdir "foo")

--- a/test/f-io-test.el
+++ b/test/f-io-test.el
@@ -1,0 +1,91 @@
+(ert-deftest f-write-bytes-test/multibyte-string ()
+  (with-sandbox
+   (let ((err (should-error (f-write-bytes "☺ ☹" "foo.txt")
+                            :type 'wrong-type-argument)))
+     (should (equal (cdr err)
+                    (list 'f-unibyte-string-p "☺ ☹"))))))
+
+(ert-deftest f-write-bytes-test/unibyte-string ()
+  (with-sandbox
+   ;; Let's take some random bytes
+   (let ((bytes (apply #'unibyte-string (-map #'random (-repeat 100 255)))))
+     ;; Make a string of our bytes
+     (f-write-bytes bytes "foo.txt")
+     (should-exist "foo.txt" bytes))))
+
+(ert-deftest f-write-text-test/unibyte-string ()
+  (with-sandbox
+   (let ((err (should-error (f-write-text (unibyte-string 1 2 3 4 5)
+                                          'utf-8 "foo.txt")
+                            :type 'wrong-type-argument)))
+     (should (equal (cdr err)
+                    (list 'multibyte-string-p (unibyte-string 1 2 3 4 5)))))))
+
+(ert-deftest f-write-text-test/multibyte-string ()
+  (with-sandbox
+   (f-write-text "☺ ☹" 'utf-8 "foo.txt")
+   (should-exist "foo.txt" (unibyte-string 226 152 186 32 226 152 185))
+   (f-write-text "blök" 'iso-8859-1 "foo.txt")
+   (should-exist "foo.txt" (unibyte-string 98 108 246 107))))
+
+(ert-deftest f-read-bytes ()
+  (with-sandbox
+   (let ((bytes (apply #'unibyte-string (-map #'random (-repeat 100 255)))))
+     (f-write-bytes bytes "foo.txt")
+     (let ((content (f-read-bytes "foo.txt")))
+       (should-not (multibyte-string-p content))
+       (should (f-unibyte-string-p content))
+       (should (string= content bytes))))))
+
+(ert-deftest f-read-text ()
+  (with-sandbox
+   (f-write-bytes (unibyte-string 226 152 185 32 226 152 186) "foo.txt")
+   (let ((text (f-read-text "foo.txt" 'utf-8)))
+     (should (string= text "☹ ☺"))
+     (should (multibyte-string-p text)))
+   (f-write-bytes (unibyte-string 252 98 101 114) "foo.txt")
+   (let ((text (f-read-text "foo.txt" 'iso-8859-1)))
+     (should (string= text "über"))
+     (should (multibyte-string-p text)))))
+
+;;; Obsolete functions
+(ert-deftest f-read-test/empty ()
+  (with-sandbox
+   (f-write "foo.txt")
+   (should (equal (f-read "foo.txt") ""))))
+
+(ert-deftest f-read-test/with-content ()
+  (with-sandbox
+   (f-write "foo.txt" "FOO")
+   (should (equal (f-read "foo.txt") "FOO"))))
+
+(ert-deftest f-write-test/no-content-relative-path ()
+  (with-sandbox
+   (f-write "foo.txt")
+   (should-exist "foo.txt")))
+
+(ert-deftest f-write-test/no-content-absolute-path ()
+  (with-sandbox
+   (let* ((dirname (expand-file-name "bar" f-sandbox-path))
+          (filename (expand-file-name "foo.txt" dirname)))
+     (make-directory dirname)
+     (f-write filename)
+     (should-exist "bar/foo.txt"))))
+
+(ert-deftest f-write-test/with-content ()
+  (with-sandbox
+   (f-write "foo.txt" "FOO")
+   (should-exist "foo.txt" "FOO")))
+
+(ert-deftest f-write-test/override ()
+  (with-sandbox
+   (f-write "foo.txt" "FOO")
+   (f-write "foo.txt" "BAR")
+   (should-exist "foo.txt" "BAR")))
+
+(ert-deftest f-write-test/append ()
+  (with-sandbox
+   (f-write "foo.txt" "FOO")
+   (should-exist "foo.txt" "FOO")
+   (f-write "foo.txt" "BAR" 'append)
+   (should-exist "foo.txt" "FOOBAR")))

--- a/test/f-stats-test.el
+++ b/test/f-stats-test.el
@@ -14,13 +14,3 @@
    (f-write "bar/foo.txt" "FOO")
    (f-write "bar/baz.txt" "BAZ")
    (should (equal (f-size "bar") 6))))
-
-(ert-deftest f-read-test/empty ()
-  (with-sandbox
-   (f-write "foo.txt")
-   (should (equal (f-read "foo.txt") ""))))
-
-(ert-deftest f-read-test/with-content ()
-  (with-sandbox
-   (f-write "foo.txt" "FOO")
-   (should (equal (f-read "foo.txt") "FOO"))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -35,8 +35,11 @@
     (should (file-exists-p path))
     (when content
       (with-temp-buffer
-        (insert-file-contents-literally path)
-        (should (equal (buffer-string) content))))))
+        (if (multibyte-string-p content)
+            (insert-file-contents path)
+          (set-buffer-multibyte nil)
+          (insert-file-contents-literally path))
+        (should (string= (buffer-string) content))))))
 
 (defun should-not-exist (filename)
   (let ((path (expand-file-name filename f-sandbox-path)))


### PR DESCRIPTION
Follow up to #4.  Rebase onto 0.6 wip, with `f-read`/`f-write` tests back (but moved to `f-io-test.el`).
