### PR TITLE
Do not validate multibyte string in f-write-text.

### DIFF
--- a/f.el
+++ b/f.el
@@ -107,8 +107,6 @@
 
 TEXT is a multibyte string.  CODING is a coding system to encode
 TEXT with.  PATH is a file name to write to."
-  (unless (multibyte-string-p text)
-    (signal 'wrong-type-argument (list 'multibyte-string-p text)))
   (f-write-bytes (encode-coding-string text coding) path))
 
 (defun f-unibyte-string-p (s)

--- a/test/f-io-test.el
+++ b/test/f-io-test.el
@@ -15,11 +15,10 @@
 
 (ert-deftest f-write-text-test/unibyte-string ()
   (with-sandbox
-   (let ((err (should-error (f-write-text (unibyte-string 1 2 3 4 5)
-                                          'utf-8 "foo.txt")
-                            :type 'wrong-type-argument)))
-     (should (equal (cdr err)
-                    (list 'multibyte-string-p (unibyte-string 1 2 3 4 5)))))))
+   (f-write-text (unibyte-string 1 2 3 4 5) 'utf-8 "foo.txt")
+   ;; Emacs only makes multibyte strings if actually required.
+   (f-write-text "bar" 'utf-8 "bar.txt")
+   (should-exist "bar.txt" "bar")))
 
 (ert-deftest f-write-text-test/multibyte-string ()
   (with-sandbox


### PR DESCRIPTION
Emacs only makes multibyte strings if actually required, so we cannot
check for multibyte string when writing text.
