### PR TITLE
Default to utf-8 when reading text.

### DIFF
--- a/f.el
+++ b/f.el
@@ -121,10 +121,10 @@ Return the binary data as unibyte string."
 (defun f-read-text (path &optional coding)
   "Read text with PATH, using CODING.
 
-CODING defaults to `prefer-utf-8'.
+CODING defaults to `utf-8'.
 
 Return the decoded text as multibyte string."
-  (decode-coding-string (f-read-bytes path) (or coding 'prefer-utf-8)))
+  (decode-coding-string (f-read-bytes path) (or coding 'utf-8)))
 
 (defun f-write (path &optional content append)
   "Write CONTENT or nothing to PATH. If no content, just create file."

--- a/test/f-io-test.el
+++ b/test/f-io-test.el
@@ -47,6 +47,10 @@
      (should (string= text "über"))
      (should (multibyte-string-p text)))))
 
+(ert-deftest f-read-text-no-coding-specified ()
+  (f-write-text "text" 'utf-8 "foo.txt")
+  (should (equal (f-read-text "foo.txt") "text")))
+
 ;;; Obsolete functions
 (ert-deftest f-read-test/empty ()
   (with-sandbox


### PR DESCRIPTION
@lunaryorn Where did you get `prefer-utf-8` from? If you remove this implementation and run the test, you will get:     `(coding-system-error prefer-utf-8)`
