### PR TITLE
Add f-common-parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-expand](#f-expand-path-optional-dir) `(path &optional dir)`
 * [f-filename](#f-filename-path) `(path)`
 * [f-dirname](#f-dirname-path) `(path)`
+* [f-common-parent](#f-common-parent-paths) `(paths)`
 * [f-ext](#f-ext-path) `(path)`
 * [f-no-ext](#f-no-ext-path) `(path)`
 * [f-base](#f-base-path) `(path)`
@@ -137,6 +138,16 @@ Alias: `f-parent`
 (f-dirname "path/to/file.ext") ;; => "path/to"
 (f-dirname "path/to/directory") ;; => "path/to"
 (f-dirname "/") ;; => nil
+```
+
+### f-common-parent `(paths)`
+
+Return the deepest common parent directory of FILES.
+
+```lisp
+(f-common-parent '("foo/bar/baz" "foo/bar/qux" "foo/bar/mux")) ;; => "foo/bar/"
+(f-common-parent '("/foo/bar/baz" "/foo/bar/qux" "/foo/bax/mux")) ;; => "/foo/"
+(f-common-parent '("foo/bar/baz" "quack/bar/qux" "lack/bar/mux")) ;; => ""
 ```
 
 ### f-ext `(path)`
@@ -342,7 +353,7 @@ Move or rename FROM to TO.
 
 ### f-copy `(from to)`
 
-Copy file or directory.
+Copy file or directory FROM to TO.
 
 ```lisp
 (f-copy "path/to/file.txt" "new-file.txt")

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -23,6 +23,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-expand](#f-expand-path-optional-dir) `(path &optional dir)`
 * [f-filename](#f-filename-path) `(path)`
 * [f-dirname](#f-dirname-path) `(path)`
+* [f-common-parent](#f-common-parent-paths) `(paths)`
 * [f-ext](#f-ext-path) `(path)`
 * [f-no-ext](#f-no-ext-path) `(path)`
 * [f-base](#f-base-path) `(path)`
@@ -137,6 +138,16 @@ Alias: `f-parent`
 (f-dirname "path/to/file.ext") ;; => "path/to"
 (f-dirname "path/to/directory") ;; => "path/to"
 (f-dirname "/") ;; => nil
+```
+
+### f-common-parent `(paths)`
+
+{{f-common-parent}}
+
+```lisp
+(f-common-parent '("foo/bar/baz" "foo/bar/qux" "foo/bar/mux")) ;; => "foo/bar/"
+(f-common-parent '("/foo/bar/baz" "/foo/bar/qux" "/foo/bax/mux")) ;; => "/foo/"
+(f-common-parent '("foo/bar/baz" "quack/bar/qux" "lack/bar/mux")) ;; => ""
 ```
 
 ### f-ext `(path)`

--- a/f.el
+++ b/f.el
@@ -91,6 +91,17 @@ If PATH is not allowed to be modified, throw error."
           (f-relative parent)
         (directory-file-name parent)))))
 
+(defun f-common-parent (paths)
+  "Return the deepest common parent directory of PATHS."
+  (let* ((paths (-map 'f-split paths))
+         (common (caar paths))
+         (re nil))
+    (while (--all? (equal (car it) common) paths)
+      (setq paths (-map 'cdr paths))
+      (push common re)
+      (setq common (caar paths)))
+    (if re (concat (apply 'f-join (nreverse re)) "/") "")))
+
 (defun f-ext (path)
   "Return the file extension of PATH."
   (file-name-extension path))

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -140,6 +140,19 @@
    (should-not (f-parent (f-root)))))
 
 
+;;;; f-common-parent
+(ert-deftest f-common-parent/directory-relative ()
+  (should (equal (f-common-parent '("foo/bar/baz" "foo/bar/qux" "foo/bar/mux")) "foo/bar/"))
+  (should (equal (f-common-parent '("foo/bar/baz" "foo/bar/qux" "foo/bax/mux")) "foo/")))
+
+(ert-deftest f-common-parent/directory-absolute ()
+  (should (equal (f-common-parent '("/foo/bar/baz" "/foo/bar/qux" "/foo/bar/mux")) "/foo/bar/"))
+  (should (equal (f-common-parent '("/foo/bar/baz" "/foo/bar/qux" "/foo/bax/mux")) "/foo/")))
+
+(ert-deftest f-common-parent/no-common-parent ()
+  (should (equal (f-common-parent '("foo/bar/baz" "foo/bar/qux" "fo/bar/mux")) "")))
+
+
 ;;;; f-ext
 
 (ert-deftest f-ext-test/no-extension ()


### PR DESCRIPTION
Return the deepest common parent directory of PATHS.

My usecase for this is getting the "current directory" for a virtual dired and trimming the common prefixes of the files. I'm sure there are many more.
