### PR TITLE
Add f-target to resolve symbolic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Or you can just dump `f.el` in your load path somewhere.
 ### Stats
 
 * [f-size](#f-size-path) `(path)`
+* [f-target](#f-target-symlink-optional-non-recursive) `(symlink &optional non-recursive)`
 
 ### Misc
 
@@ -342,7 +343,7 @@ Move or rename FROM to TO.
 
 ### f-copy `(from to)`
 
-Copy file or directory.
+Copy file or directory FROM to TO.
 
 ```lisp
 (f-copy "path/to/file.txt" "new-file.txt")

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -73,6 +73,7 @@ Or you can just dump `f.el` in your load path somewhere.
 ### Stats
 
 * [f-size](#f-size-path) `(path)`
+* [f-target](#f-target-symlink-optional-non-recursive) `(symlink &optional non-recursive)`
 
 ### Misc
 

--- a/f.el
+++ b/f.el
@@ -358,6 +358,17 @@ directory, return sum of all files in PATH."
       (-sum (-map 'f-size (f-files path nil t)))
     (nth 7 (file-attributes path))))
 
+(defun f-target (symlink &optional non-recursive)
+  "Return the file SYMLINK points to, recursively.
+
+If SYMLINK is not a symbolic link, just return SYMLINK.
+
+If NON-RECURSIVE is non-nil, resolve only the first indirection."
+  (if (file-symlink-p symlink)
+      (let ((target (car (file-attributes symlink))))
+        (if non-recursive target (f-target target non-recursive)))
+    symlink))
+
 
 ;;;; Misc
 

--- a/test/f-stats-test.el
+++ b/test/f-stats-test.el
@@ -45,6 +45,29 @@
    (f-write "BAZ" 'utf-8 "bar/baz.txt")
    (should (equal (f-size "bar") 6))))
 
+
+;;;; f-target
+
+(ert-deftest f-target-test/non-symlink ()
+  (with-playground
+   (f-touch "foo.txt")
+   (should (equal (f-target "foo.txt") "foo.txt"))))
+
+(ert-deftest f-target-test/recursive ()
+  (with-playground
+   (f-touch "foo.txt")
+   (f-symlink "foo.txt" "bar")
+   (f-symlink "bar" "baz")
+   (should (equal (f-target "baz") "foo.txt"))))
+
+(ert-deftest f-target-test/non-recursive ()
+  (with-playground
+   (f-touch "foo.txt")
+   (f-symlink "foo.txt" "bar")
+   (f-symlink "bar" "baz")
+   (should (equal (f-target "baz" :non-recursive) "bar"))
+   (should (equal (f-target "bar" :non-recursive) "foo.txt"))))
+
 (provide 'f-stats-test)
 
 ;;; f-stats-test.el ends here


### PR DESCRIPTION
In "standard elisp" one has to use `file-attributes` which is absolutely unintuitive (took me godawful amount of time to figure that out).  This also resolves the links recursively by default because that's what we usually want: to get the _real_ find all this network of links points to.
