### PR TITLE
Fix f-common-parent if input list has just one element

### DIFF
--- a/f.el
+++ b/f.el
@@ -93,14 +93,18 @@ If PATH is not allowed to be modified, throw error."
 
 (defun f-common-parent (paths)
   "Return the deepest common parent directory of PATHS."
-  (let* ((paths (-map 'f-split paths))
-         (common (caar paths))
-         (re nil))
-    (while (--all? (equal (car it) common) paths)
-      (setq paths (-map 'cdr paths))
-      (push common re)
-      (setq common (caar paths)))
-    (if re (concat (apply 'f-join (nreverse re)) "/") "")))
+  (cond
+   ((not paths) nil)
+   ((not (cdr paths)) (f-parent (car paths)))
+   (:otherwise
+    (let* ((paths (-map 'f-split paths))
+           (common (caar paths))
+           (re nil))
+      (while (--all? (equal (car it) common) paths)
+        (setq paths (-map 'cdr paths))
+        (push common re)
+        (setq common (caar paths)))
+      (if re (concat (apply 'f-join (nreverse re)) "/") "")))))
 
 (defun f-ext (path)
   "Return the file extension of PATH."

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -152,6 +152,13 @@
 (ert-deftest f-common-parent/no-common-parent ()
   (should (equal (f-common-parent '("foo/bar/baz" "foo/bar/qux" "fo/bar/mux")) "")))
 
+(ert-deftest f-common-parent/single-file ()
+  (should (equal (f-common-parent '("foo/bar/baz")) "foo/bar/"))
+  (should (equal (f-common-parent '("baz")) "./")))
+
+(ert-deftest f-common-parent/empty-list ()
+  (should (equal (f-common-parent nil) nil)))
+
 
 ;;;; f-ext
 


### PR DESCRIPTION
I've run into this issue just now. It goes into infinite loop if the input list has just one element.

Somehow this possibility slipped my mind when I wrote this originally. But we should always think about the edge conditions, so here's the fix. I've also added a test so this is covered in the future.

Sorry for the noise :/
