### PR TITLE
Added: test coverage with undercover.el

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,4 +7,5 @@
  (depends-on "ert-runner")
  (depends-on "s")
  (depends-on "dash")
- (depends-on "cask"))
+ (depends-on "cask")
+ (depends-on "undercover"))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# f.el [![Build Status](https://api.travis-ci.org/rejeep/f.el.png?branch=master)](http://travis-ci.org/rejeep/f.el)
+# f.el [![Build Status](https://api.travis-ci.org/rejeep/f.el.png?branch=master)](http://travis-ci.org/rejeep/f.el) [![Coverage Status](https://img.shields.io/coveralls/rejeep/f.el.svg)](https://coveralls.io/r/rejeep/f.el)
 
 Much inspired by [@magnars](https://github.com/magnars)'s excellent
 [s.el](https://github.com/magnars/s.el) and

--- a/test/f-init.el
+++ b/test/f-init.el
@@ -25,6 +25,9 @@
 
 ;;; Code:
 
+(require 'undercover)
+(undercover "/f\\.el$")
+
 (defvar f-test/test-path
   (directory-file-name (file-name-directory load-file-name))
   "Path to tests directory.")


### PR DESCRIPTION
Hi!

I'm author of new library [undercover.el](https://github.com/sviridov/undercover.el) that provides a test coverage check for Emacs packages.

This commit adds coverage check for `f.el` package. [See](https://coveralls.io/files/310505744) my fork coverage results.

It will be awesome if you accept this commit! Thanks!
