### PR TITLE
Fix for: f-slash for non-existent directories #29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - EVM_EMACS=emacs-24.2-bin
   - EVM_EMACS=emacs-24.3-bin
   - EVM_EMACS=emacs-24.4-bin
+  - EVM_EMACS=emacs-24.5-bin
 script:
   - emacs --version
   - make test

--- a/f.el
+++ b/f.el
@@ -43,6 +43,11 @@
 
 Do not modify this variable.")
 
+(defvar f-slash-force-directory-file-name nil
+  "Forces f-slash to always return directory-file-name path.
+
+This variable should be scoped with let, if there is a need to work with not existing directories.")
+
 (defmacro f--destructive (path &rest body)
   "If PATH is allowed to be modified, yield BODY.
 
@@ -152,7 +157,8 @@ EXT must not be nil or empty."
 
 Some functions, such as `call-process' requires there to be an
 ending slash."
-  (if (f-dir? path)
+  (if (or f-slash-force-directory-file-name
+	  (f-dir? path))
       (file-name-as-directory path)
     path))
 

--- a/test/f-predicates-test.el
+++ b/test/f-predicates-test.el
@@ -307,6 +307,15 @@
    (should-not (f-ancestor-of? "foo/bar/baz/qux" "foo/bar/baz/qux"))
    (should-not (f-ancestor-of? (f-root) (f-root)))))
 
+(ert-deftest f-ancestor-of?-test/is-not-ancestor-not-existing-partial-named ()
+  (with-playground
+   (f-mkdir "foo" "bar" "baz" "qux")
+   (let ((f-slash-force-directory-file-name t))
+     (should-not (f-ancestor-of? "fo" "foo"))
+     (should-not (f-ancestor-of? "fo" "foo/bar"))
+     (should-not (f-ancestor-of? "foo/ba" "foo/bar/baz"))
+     (should-not (f-ancestor-of? "foo/bar/ba" "foo/bar/baz/qux")))))
+
 
 ;;;; f-descendant-of?
 


### PR DESCRIPTION
Lets temporary override the behaviour of `f-slash`.

The discussion is in [issue 29](https://github.com/rejeep/f.el/issues/29/ "Issue 29").