### PR TITLE
Fix broken `f-relative' link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-no-ext](#f-no-ext-path) `(path)`
 * [f-swap-ext](#f-swap-ext) `(path ext)`
 * [f-base](#f-base-path) `(path)`
-* [f-relative](#f-relative-path-optional-file) `(path &optional file)`
+* [f-relative](#f-relative-path-optional-dir) `(path &optional dir)`
 * [f-short](#f-short-path) `(path)`
 * [f-long](#f-long-path) `(path)`
 * [f-canonical](#f-canonical-path) `(path)`

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -28,7 +28,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-no-ext](#f-no-ext-path) `(path)`
 * [f-swap-ext](#f-swap-ext) `(path ext)`
 * [f-base](#f-base-path) `(path)`
-* [f-relative](#f-relative-path-optional-file) `(path &optional file)`
+* [f-relative](#f-relative-path-optional-dir) `(path &optional dir)`
 * [f-short](#f-short-path) `(path)`
 * [f-long](#f-long-path) `(path)`
 * [f-canonical](#f-canonical-path) `(path)`


### PR DESCRIPTION
It pointed to `#f-relative-path-optional-file` when it should actually point to `#f-relative-path-optional-dir`.