### PR TITLE
Fix `f-common-parent` bug with same paths

### DIFF
--- a/f.el
+++ b/f.el
@@ -100,7 +100,7 @@ If PATH is not allowed to be modified, throw error."
     (let* ((paths (-map 'f-split paths))
            (common (caar paths))
            (re nil))
-      (while (--all? (equal (car it) common) paths)
+      (while (and (not (null (car paths))) (--all? (equal (car it) common) paths))
         (setq paths (-map 'cdr paths))
         (push common re)
         (setq common (caar paths)))

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -159,6 +159,10 @@
   (should (equal (f-common-parent '("foo/bar/baz")) "foo/bar/"))
   (should (equal (f-common-parent '("baz")) "./")))
 
+(ert-deftest f-common-parent/same-path ()
+  (should (equal (f-common-parent '("foo/bar/baz" "foo/bar/baz")) "foo/bar/baz/"))
+  (should (equal (f-common-parent '("foo" "foo")) "foo/")))
+
 (ert-deftest f-common-parent/empty-list ()
   (should (equal (f-common-parent nil) nil)))
 


### PR DESCRIPTION
Doing `(f-common-parent '("keke" "keke"))` does an infinite loop.

Didn't test it much, please do :)