### PR TITLE
Disable file name handlers

### DIFF
--- a/f.el
+++ b/f.el
@@ -76,7 +76,8 @@ If PATH is not allowed to be modified, throw error."
 
 (defun f-expand (path &optional dir)
   "Expand PATH relative to DIR (or `default-directory')."
-  (directory-file-name (expand-file-name path dir)))
+  (let (file-name-handler-alist)
+    (directory-file-name (expand-file-name path dir))))
 
 (defun f-filename (path)
   "Return the name of PATH."

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -77,6 +77,11 @@
   (with-default-directory
    (should (equal (f-expand "foo" "/other") "/other/foo"))))
 
+(ert-deftest f-expand-test/skip-handlers ()
+  ;; If handlers are used, Tramp will try to connect but fail with an
+  ;; exception, hence this will fail.
+  (f-expand "foo:" "/"))
+
 
 ;;;; f-filename
 


### PR DESCRIPTION
Otherwise an expression like this would try to connect using Tramp:

```lisp
(f-join (f-root) "C:\\Users\\61169.html")
```