### PR TITLE
Fix =f-uniquify-alist= infinite loop with =projectile-current-project…

### DIFF
--- a/f.el
+++ b/f.el
@@ -167,7 +167,12 @@ ending slash."
 (defun f--uniquify (paths)
   "Helper for `f-uniquify' and `f-uniquify-alist'."
   (let* ((files-length (length paths))
-         (uniq-filenames (--map (cons it (f-filename it)) paths))
+         (path-name (lambda (path)
+                      (let ((base-name (f-filename path)))
+                        (if (string-equal (f-path-separator) (s-right 1 path))
+                            (concat base-name (f-path-separator))
+                          base-name))))
+         (uniq-filenames (--map (cons it (funcall path-name it)) paths))
          (uniq-filenames-next (-group-by 'cdr uniq-filenames)))
     (while (/= files-length (length uniq-filenames-next))
       (setq uniq-filenames-next
@@ -175,7 +180,7 @@ ending slash."
                        (--mapcat
                         (let ((conf-files (cdr it)))
                           (if (> (length conf-files) 1)
-                              (--map (cons (car it) (concat (f-filename (s-chop-suffix (cdr it) (car it))) (f-path-separator) (cdr it))) conf-files)
+                              (--map (cons (car it) (concat (funcall path-name (s-chop-suffix (cdr it) (car it))) (cdr it))) conf-files)
                             conf-files))
                         uniq-filenames-next))))
     uniq-filenames-next))

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -395,6 +395,9 @@
 (ert-deftest f-uniquify-alist/single-conflict-shared-subpath ()
   (should (equal (f-uniquify-alist '("/foo/bar" "/www/bar" "/www/bar/quux")) '(("/foo/bar" . "foo/bar") ("/www/bar" . "www/bar") ("/www/bar/quux" . "quux")))))
 
+(ert-deftest f-uniquify-alist/projectile-dirs ()
+  (should (equal (f-uniquify-alist '("/bar/foo/" "/baz/foo/")) '(("/bar/foo/" . "bar/foo/") ("/baz/foo/" . "baz/foo/")))))
+
 (ert-deftest f-uniquify-alist/recursive-conflict ()
   (should (equal (f-uniquify-alist '("/foo/bar" "/foo/baz" "/home/www/bar" "/home/www/baz" "/var/foo" "/opt/foo/www/baz"))
                  '(("/foo/bar" . "foo/bar") ("/home/www/bar" . "www/bar") ("/foo/baz" . "foo/baz") ("/home/www/baz" . "home/www/baz") ("/opt/foo/www/baz" . "foo/www/baz") ("/var/foo" . "foo")) )))


### PR DESCRIPTION
This is my fix for the infinite loop when using `f-uniquify-alist` with `projectile-current-project-dirs` or #62 . 

I simply made a wrapper for `f-filename` when the path has an separator at the end it also adds it. 