### PR TITLE
Add f-change-time, f-modification-time, f-access-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Or you can just dump `f.el` in your load path somewhere.
 
 * [f-size](#f-size-path) `(path)`
 * [f-depth](#f-depth-path) `(path)`
+* [f-change-time](#f-change-time) `(path)`
+* [f-modification-time](#f-modification-time) `(path)`
+* [f-access-time](#f-access-time) `(path)`
 
 ### Misc
 
@@ -571,6 +574,39 @@ detect the depth.
 (f-depth "/") ;; 0
 (f-depth "/var/") ;; 1
 (f-depth "/usr/local/bin") ;; 3
+```
+
+### f-change-time `(path)`
+
+Return the last status change time (ctime) of path in the same format as `current-time'.
+
+See `file-attributes' for technical details.
+
+```lisp
+(f-change-time "path/to/file.txt")
+(f-change-time "path/to/dir")
+```
+
+### f-modification-time `(path)`
+
+Return the last modification time (mtime)of path in the same format as `current-time'.
+
+See `file-attributes' for technical details.
+
+```lisp
+(f-modification-time "path/to/file.txt")
+(f-modification-time "path/to/dir")
+```
+
+### f-access-time `(path)`
+
+Return the last access time (atime) of path in the same format as `current-time'.
+
+See `file-attributes' for technical details.
+
+```lisp
+(f-access-time "path/to/file.txt")
+(f-access-time "path/to/dir")
 ```
 
 ### f-this-file `()`

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -76,6 +76,9 @@ Or you can just dump `f.el` in your load path somewhere.
 
 * [f-size](#f-size-path) `(path)`
 * [f-depth](#f-depth-path) `(path)`
+* [f-change-time](#f-change-time) `(path)`
+* [f-modification-time](#f-modification-time) `(path)`
+* [f-access-time](#f-access-time) `(path)`
 
 ### Misc
 
@@ -534,6 +537,33 @@ Alias: `f-equal?`
 (f-depth "/") ;; 0
 (f-depth "/var/") ;; 1
 (f-depth "/usr/local/bin") ;; 3
+```
+
+### f-change-time `(path)`
+
+{{f-change-time}}
+
+```lisp
+(f-change-time "path/to/file.txt")
+(f-change-time "path/to/dir")
+```
+
+### f-modification-time `(path)`
+
+{{f-modification-time}}
+
+```lisp
+(f-modification-time "path/to/file.txt")
+(f-modification-time "path/to/dir")
+```
+
+### f-access-time `(path)`
+
+{{f-access-time}}
+
+```lisp
+(f-access-time "path/to/file.txt")
+(f-access-time "path/to/dir")
 ```
 
 ### f-this-file `()`

--- a/f.el
+++ b/f.el
@@ -400,6 +400,24 @@ detect the depth.
 '/' will be zero depth, '/usr' will be one depth. And so on."
   (- (length (f-split (f-expand path))) 1))
 
+(defun f-change-time (path)
+  "Return the last status change time (ctime) of path in the same format as `current-time'.
+
+See `file-attributes' for technical details."
+  (nth 6 (file-attributes path)))
+
+(defun f-modification-time (path)
+  "Return the last modification time (mtime)of path in the same format as `current-time'.
+
+See `file-attributes' for technical details."
+  (nth 5 (file-attributes path)))
+
+(defun f-access-time (path)
+  "Return the last access time (atime) of path in the same format as `current-time'.
+
+See `file-attributes' for technical details."
+  (nth 4 (file-attributes path)))
+
 
 ;;;; Misc
 

--- a/test/f-stats-test.el
+++ b/test/f-stats-test.el
@@ -55,6 +55,29 @@
   (should (equal (f-depth "/usr/local/bin/rails") 4))
   (should (equal (f-depth "/opt/git/f") 3)))
 
+;;;; f-change-time
+
+(ert-deftest f-change-time/return-time-for-file ()
+  (with-playground
+    (f-touch "foo.txt")
+    (should (equal (length (f-change-time "foo.txt")) 4))))
+
+;;;; f-modification-time
+
+(ert-deftest f-modification-time/return-time-for-file ()
+  (with-playground
+    (f-touch "foo.txt")
+    (should (equal (length (f-modification-time "foo.txt")) 4))))
+
+;;;; f-access-time
+
+(ert-deftest f-access-time/return-time-for-file ()
+  (with-playground
+    (f-touch "foo.txt")
+    (should (equal (length (f-access-time "foo.txt")) 4))))
+
+
 (provide 'f-stats-test)
 
 ;;; f-stats-test.el ends here
+


### PR DESCRIPTION
Adds `f-change-time`, `f-modification-time`, `f-access-time` convenience functions.  Returns time in same format as `current-time` and `file-attributes` (`(HIGH LOW USEC PSEC)`).  Formatting of the datetime may be done with external functions such as `format-time-string`.
