### PR TITLE
f-traverse-upwards: Don't require path to exist.

### DIFF
--- a/f.el
+++ b/f.el
@@ -566,8 +566,6 @@ returned."
     (setq path default-directory))
   (when (f-relative? path)
     (setq path (f-expand path)))
-  (unless (f-exists? path)
-    (error "File %s does not exist" path))
   (if (funcall fn path)
       path
     (unless (f-root? path)

--- a/test/f-misc-test.el
+++ b/test/f-misc-test.el
@@ -309,9 +309,6 @@
         (lambda (path)
           (f-file? (f-expand "foo" path)))))))))
 
-(ert-deftest f-traverse-upwards-test/specified-path-does-not-exist ()
-  (should-error (f-traverse-upwards 'ignore "does-not-exist")))
-
 (ert-deftest f-traverse-upwards-test/specified-path-is-file ()
   (with-playground
    (f-touch "foo")


### PR DESCRIPTION
None of the functionality depends on this.

Fixes #67