### PR TITLE
Add reject-paths parameter for skipping certain directories from traversing.

### DIFF
--- a/f.el
+++ b/f.el
@@ -525,7 +525,8 @@ detect the depth.
 
 FN - called for each found file and directory.  If FN returns a thruthy
 value, file or directory will be included.
-RECURSIVE - Search for files and directories recursive."
+RECURSIVE - Search for files and directories recursive.
+REJECT-PATHS - List of strings containing names to be skipped from traversing."
   (let ((entries (f--collect-entries path recursive reject-paths)))
     (if fn (-select fn entries) entries)))
 

--- a/test/f-misc-test.el
+++ b/test/f-misc-test.el
@@ -94,6 +94,21 @@
      (--map (f-relative it "foo") (f-entries "foo" nil t))
      '("bar.el" "bar" "bar/qux" "bar/baz.el" "bar/qux/hey.el")))))
 
+(ert-deftest f-entries-test/with-reject-paths ()
+  (with-playground
+   (f-mkdir "foo")
+   (f-touch "foo/bar.txt")
+   (f-touch "foo/baz.txt")
+   (f-mkdir "foo/qux")
+   (f-mkdir "foo/ignore")
+   (f-mkdir "foo/ignore/ignore_inner")
+   (f-touch "foo/ignore/ignore_inner/1.txt")
+   (f-touch "foo/ignore/ignore_inner/2.txt")
+   (should
+    (equal
+     (--map (f-relative it "foo") (f-entries "foo" nil t (list "ignore_inner")))
+     '("qux" "baz.txt" "bar.txt" "ignore")))))
+
 (ert-deftest f-entries-test/anaphoric ()
   (with-playground
    (f-mkdir "foo")

--- a/test/f-misc-test.el
+++ b/test/f-misc-test.el
@@ -107,7 +107,7 @@
    (should
     (equal
      (--map (f-relative it "foo") (f-entries "foo" nil t (list "ignore_inner")))
-     '("qux" "baz.txt" "bar.txt" "ignore")))))
+     '("qux" "ignore" "baz.txt" "bar.txt")))))
 
 (ert-deftest f-entries-test/anaphoric ()
   (with-playground


### PR DESCRIPTION
Extend f--collect-entries with an optional reject-paths argument for ignoring certain folders from being traversed. Useful when scanning through source code folders which contain .git/, .svn/, .gradle/, build/ folders.
