### PR TITLE
f-absolute? checks for tilde character as relative path

### DIFF
--- a/f.el
+++ b/f.el
@@ -7,7 +7,7 @@
 ;; Version: 0.18.2
 ;; Keywords: files, directories
 ;; URL: http://github.com/rejeep/f.el
-;; Package-Requires: ((s "1.7.0") (dash "2.2.0"))
+;; Package-Requires: ((emacs "24") (s "1.7.0") (dash "2.2.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -329,7 +329,9 @@ If FORCE is t, a directory will be deleted recursively."
 
 (defun f-absolute? (path)
   "Return t if PATH is absolute, false otherwise."
-  (file-name-absolute-p path))
+  (if (string-prefix-p "~" path)
+      nil
+    (file-name-absolute-p path)))
 
 (defun f-relative? (path)
   "Return t if PATH is relative, false otherwise."

--- a/test/f-predicates-test.el
+++ b/test/f-predicates-test.el
@@ -135,6 +135,9 @@
 (ert-deftest f-absolute?-test/is-absolute ()
   (should (f-absolute? "/full/path/to/dir")))
 
+(ert-deftest f-absolute?-test/is-tilde-not-absolute ()
+  (should-not (f-absolute? "~/a/path/from/home")))
+
 (ert-deftest f-absolute?-test/is-relative ()
   (should-not (f-absolute? "path/to/dir")))
 


### PR DESCRIPTION
This simply tags paths that start with "~" as relative using `f-absolute?`.

This should resolve #80.