### PR TITLE
Simplify f-write-bytes and f-append-bytes

### DIFF
--- a/f.el
+++ b/f.el
@@ -235,15 +235,7 @@ TEXT with.  PATH is a file name to write to."
   "Write binary DATA to PATH.
 
 DATA is a unibyte string.  PATH is a file name to write to."
-  (f--destructive path
-    (unless (f-unibyte-string-p data)
-      (signal 'wrong-type-argument (list 'f-unibyte-string-p data)))
-    (let ((file-coding-system-alist nil)
-          (coding-system-for-write 'binary))
-      (with-temp-file path
-        (setq buffer-file-coding-system 'binary)
-        (set-buffer-multibyte nil)
-        (insert data)))))
+  (f--write-bytes data path nil))
 
 (defalias 'f-append 'f-append-text)
 (defun f-append-text (text coding path)
@@ -256,11 +248,19 @@ If PATH does not exist, it is created."
   "Append binary DATA to PATH.
 
 If PATH does not exist, it is created."
-  (let ((content
-         (if (f-file? path)
-             (f-read-bytes path)
-           "")))
-    (f-write-bytes (concat content data) path)))
+  (f--write-bytes data path :append))
+
+(defun f--write-bytes (data filename append)
+  "Write binary DATA to FILENAME.
+If APPEND is non-nil, append the DATA to the existing contents."
+  (f--destructive filename
+    (unless (f-unibyte-string-p data)
+      (signal 'wrong-type-argument (list 'f-unibyte-string-p data)))
+    (let ((coding-system-for-write 'binary)
+          (write-region-annotate-functions nil)
+          (write-region-post-annotation-function nil))
+      (write-region data nil filename append :silent)
+      nil)))
 
 
 ;;;; Destructive


### PR DESCRIPTION
Instead of a temporary buffer, just call write-region with the string itself.
write-region always uses coding-system-for-write if set, so we don’t have to
set the other coding-related variables.  However, we should bind the annotation
functions so that they don’t mess with the output.

Use write-region for appending text as well.  This simplifies the code and
eliminates a race condition.  While there, make the operation silent.