### PR TITLE
Adapt to changes in Emacs 26

### DIFF
--- a/f.el
+++ b/f.el
@@ -284,11 +284,14 @@ If FORCE is t, a directory will be deleted recursively."
   (f--destructive path (make-symbolic-link source path)))
 
 (defun f-move (from to)
-  "Move or rename FROM to TO."
+  "Move or rename FROM to TO.
+If TO is a directory name, move FROM into TO."
   (f--destructive to (rename-file from to t)))
 
 (defun f-copy (from to)
-  "Copy file or directory FROM to TO."
+  "Copy file or directory FROM to TO.
+If FROM names a directory and TO is a directory name, copy FROM
+into TO as a subdirectory."
   (f--destructive to
     (if (f-file? from)
         (copy-file from to)
@@ -312,7 +315,7 @@ If FORCE is t, a directory will be deleted recursively."
   (unless (f-dir? from)
     (error "Cannot copy contents as %s is a file" from))
   (--each (f-entries from)
-    (f-copy it to)))
+    (f-copy it (file-name-as-directory to))))
 
 (defun f-touch (path)
   "Update PATH last modification date or create if it does not exist."

--- a/test/f-destructive-test.el
+++ b/test/f-destructive-test.el
@@ -103,7 +103,7 @@
   (with-playground
    (f-touch "foo.txt")
    (f-mkdir "bar")
-   (f-move "foo.txt" "bar")
+   (f-move "foo.txt" "bar/")
    (should-exist "bar/foo.txt")))
 
 (ert-deftest f-move-test/move-absolute-path ()
@@ -112,7 +112,7 @@
    (f-mkdir "bar")
    (f-move
     (f-expand "foo.txt" f-test/playground-path)
-    (f-expand "bar" f-test/playground-path))
+    (file-name-as-directory (f-expand "bar" f-test/playground-path)))
    (should-exist "bar/foo.txt")))
 
 (ert-deftest f-move-test/rename-relative-path ()
@@ -153,7 +153,7 @@
    (f-mkdir "foo")
    (f-mkdir "bar")
    (f-write "FILE" 'utf-8 "foo/file.txt")
-   (f-copy "foo" "bar")
+   (f-copy "foo" "bar/")
    (should-exist "foo/file.txt" "FILE")
    (should-exist "bar/foo/file.txt" "FILE")))
 
@@ -172,7 +172,7 @@
    (f-write "FILE" 'utf-8 "foo/file.txt")
    (f-copy
     (f-expand "foo" f-test/playground-path)
-    (f-expand "bar" f-test/playground-path))
+    (file-name-as-directory (f-expand "bar" f-test/playground-path)))
    (should-exist "foo/file.txt" "FILE")
    (should-exist "bar/foo/file.txt" "FILE")))
 


### PR DESCRIPTION
In Emacs 26, copy-directory and rename-file no longer test whether their
destination argument is a directory because that introduces a filesystem race
with possible security implications.  Rather, they check whether the argument
is a directory name or not.

Fixes #83