### PR TITLE
Have f-expand return a directory name if a directory name is given

### DIFF
--- a/f.el
+++ b/f.el
@@ -75,9 +75,13 @@ If PATH is not allowed to be modified, throw error."
       parts)))
 
 (defun f-expand (path &optional dir)
-  "Expand PATH relative to DIR (or `default-directory')."
+  "Expand PATH relative to DIR (or `default-directory').
+PATH and DIR can be either a directory names or directory file
+names.  Return a directory name if PATH is a directory name, and
+a directory file name otherwise.  File name handlers are
+ignored."
   (let (file-name-handler-alist)
-    (directory-file-name (expand-file-name path dir))))
+    (expand-file-name path dir)))
 
 (defun f-filename (path)
   "Return the name of PATH."
@@ -86,7 +90,8 @@ If PATH is not allowed to be modified, throw error."
 (defalias 'f-parent 'f-dirname)
 (defun f-dirname (path)
   "Return the parent directory to PATH."
-  (let ((parent (file-name-directory (f-expand path default-directory))))
+  (let ((parent (file-name-directory
+                 (directory-file-name (f-expand path default-directory)))))
     (unless (f-same? path parent)
       (if (f-relative? path)
           (f-relative parent)
@@ -412,8 +417,8 @@ The extension, in a file name, is the part that follows the last
   (when (and (f-exists? path-a)
              (f-exists? path-b))
     (equal
-     (f-canonical (f-expand path-a))
-     (f-canonical (f-expand path-b)))))
+     (f-canonical (directory-file-name (f-expand path-a)))
+     (f-canonical (directory-file-name (f-expand path-b))))))
 
 (defalias 'f-same-p 'f-same?)
 

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -82,6 +82,10 @@
   ;; exception, hence this will fail.
   (f-expand "foo:" "/"))
 
+(ert-deftest f-expand-test/directory-name ()
+  (with-default-directory
+   (should (equal (f-expand "foo/" "/other/") "/other/foo/"))))
+
 
 ;;;; f-filename
 
@@ -117,7 +121,7 @@
    (should
     (equal
      (f-dirname (f-expand "foo/bar/baz" f-test/playground-path))
-     (f-expand "foo/bar/" f-test/playground-path)))))
+     (f-expand "foo/bar" f-test/playground-path)))))
 
 (ert-deftest f-dirname-test/file-absolute ()
   (with-playground
@@ -126,7 +130,7 @@
    (should
     (equal
      (f-dirname (f-expand "foo/bar/baz/qux.txt" f-test/playground-path))
-     (f-expand "foo/bar/baz/" f-test/playground-path)))))
+     (f-expand "foo/bar/baz" f-test/playground-path)))))
 
 (ert-deftest f-dirname-test/file-with-ending-slash ()
   (with-playground


### PR DESCRIPTION
Various Emacs functions distinguish between directory names and directory file
names, so f.el functions shouldn’t silently convert from one to the other.