### PR TITLE
Fix f-hidden? to work with subdirectories

### DIFF
--- a/f.el
+++ b/f.el
@@ -456,7 +456,7 @@ The extension, in a file name, is the part that follows the last
   "Return t if PATH is hidden, nil otherwise."
   (unless (f-exists? path)
     (error "Path does not exist: %s" path))
-  (string= (substring path 0 1) "."))
+  (string= (substring (car (last (f-split path))) 0 1) "."))
 
 (defalias 'f-hidden-p 'f-hidden?)
 

--- a/test/f-predicates-test.el
+++ b/test/f-predicates-test.el
@@ -402,21 +402,38 @@
      (should (string= (error-message-string err) "Path does not exist: foo"))
      (funcall done))))
 
-(ert-deftest f-hidden?-test/is-hidden ()
+(ert-deftest f-hidden-p-test/is-hidden ()
   (with-playground
    (f-mkdir "foo")
+   (f-mkdir "foo" ".baz")
    (f-touch "foo/.bar")
-   (f-mkdir "foo/.baz")
-   (should (f-hidden? "foo/.bar"))
-   (should (f-hidden? "foo/.baz"))))
+   (should (f-hidden-p "foo/.bar"))
+   (should (f-hidden-p "foo/.baz"))))
 
-(ert-deftest f-hidden?-test/is-not-hidden ()
+(ert-deftest f-hidden-p-test/is-not-hidden ()
   (with-playground
    (f-mkdir "foo")
-   (f-touch "foo/bar")
-   (f-mkdir "foo/baz")
-   (should-not (f-hidden? "foo/bar"))
-   (should-not (f-hidden? "foo/baz"))))
+   (f-touch "bar")
+   (f-touch "foo/baz")
+   (f-mkdir "foo/qux")
+   (should-not (f-hidden-p "foo"))
+   (should-not (f-hidden-p "bar"))
+   (should-not (f-hidden-p "foo/baz"))
+   (should-not (f-hidden-p "foo/qux"))))
+
+(ert-deftest f-hidden-p-test/subdir-is-hidden ()
+  (with-playground
+   (f-mkdir "foo" ".bar")
+   (f-touch "foo/.baz")
+   (should (f-hidden-p "foo/.bar"))
+   (should (f-hidden-p "foo/.baz"))))
+
+(ert-deftest f-hidden-p/subdir-is-not-hidden ()
+  (with-playground
+   (f-mkdir ".foo" "bar")
+   (f-touch ".foo/baz")
+   (should-not (f-hidden-p ".foo/bar"))
+   (should-not (f-hidden-p ".foo/baz"))))
 
 ;;; f-empty?
 

--- a/test/f-predicates-test.el
+++ b/test/f-predicates-test.el
@@ -404,17 +404,19 @@
 
 (ert-deftest f-hidden?-test/is-hidden ()
   (with-playground
-   (f-touch ".foo")
-   (f-mkdir ".bar")
-   (should (f-hidden? ".foo"))
-   (should (f-hidden? ".bar"))))
+   (f-mkdir "foo")
+   (f-touch "foo/.bar")
+   (f-mkdir "foo/.baz")
+   (should (f-hidden? "foo/.bar"))
+   (should (f-hidden? "foo/.baz"))))
 
 (ert-deftest f-hidden?-test/is-not-hidden ()
   (with-playground
-   (f-touch "foo")
-   (f-mkdir "bar")
-   (should-not (f-hidden? "foo"))
-   (should-not (f-hidden? "bar"))))
+   (f-mkdir "foo")
+   (f-touch "foo/bar")
+   (f-mkdir "foo/baz")
+   (should-not (f-hidden? "foo/bar"))
+   (should-not (f-hidden? "foo/baz"))))
 
 ;;; f-empty?
 


### PR DESCRIPTION
Currently `f-hidden?`'s implementation doesn't work with subdirectories, even when the documentation ( https://github.com/rejeep/f.el#f-hidden-path ) shows it should be otherwise.

This PR fixes it and changes the tests so that they test on subdirectories.