### PR TITLE
f-split should not put a / in front if it's not the first character

### DIFF
--- a/f.el
+++ b/f.el
@@ -70,7 +70,7 @@ If PATH is not allowed to be modified, throw error."
 (defun f-split (path)
   "Split PATH and return list containing parts."
   (let ((parts (s-split (f-path-separator) path 'omit-nulls)))
-    (if (f-absolute? path)
+    (if (string= (s-left 1 path) (f-path-separator))
         (push (f-path-separator) parts)
       parts)))
 

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -53,6 +53,12 @@
 (ert-deftest f-split-test/single-path-absolute ()
   (should (equal (f-split "/path") '("/" "path"))))
 
+(ert-deftest f-split-test/tilde-path-absolute ()
+  (should (equal (f-split "~/path") '("~" "path"))))
+
+(ert-deftest f-split-test/windows-path-absolute ()
+  (should (equal (f-split "C:/path") '("C:" "path"))))
+
 (ert-deftest f-split-test/multiple-paths-relative ()
   (should (equal (f-split "path/to/file") '("path" "to" "file"))))
 


### PR DESCRIPTION
Would close #80.

Putting a path separator in front whenever a directory is absolute breaks in two cases:
- When the directory starts with a `~`, which is still absolute
- When we're dealing with a Windows path (beginning with the drive letter)

Thus, a path separator should only be pushed to the parts of it is the first character.

The code in this PR comes with the assumption that path separators are always one character, but I found this assumption being made in other places too, so I guess it should be fine.