### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-common-parent](#f-common-parent-paths) `(paths)`
 * [f-ext](#f-ext-path) `(path)`
 * [f-no-ext](#f-no-ext-path) `(path)`
-* [f-swap-ext](#f-swap-ext-path-ext) `(path ext)`
+* [f-swap-ext](#f-swap-ext) `(path ext)`
 * [f-base](#f-base-path) `(path)`
 * [f-relative](#f-relative-path-optional-dir) `(path &optional dir)`
 * [f-short](#f-short-path) `(path)`
@@ -119,6 +119,10 @@ Split PATH and return list containing parts.
 ### f-expand `(path &optional dir)`
 
 Expand PATH relative to DIR (or ‘default-directory’).
+PATH and DIR can be either a directory names or directory file
+names.  Return a directory name if PATH is a directory name, and
+a directory file name otherwise.  File name handlers are
+ignored.
 
 ```lisp
 (f-expand "name") ;; => "/default/directory/name"
@@ -387,6 +391,7 @@ Create a symlink to SOURCE from PATH.
 ### f-move `(from to)`
 
 Move or rename FROM to TO.
+If TO is a directory name, move FROM into TO.
 
 ```lisp
 (f-move "path/to/file.txt" "new-file.txt")
@@ -396,6 +401,8 @@ Move or rename FROM to TO.
 ### f-copy `(from to)`
 
 Copy file or directory FROM to TO.
+If FROM names a directory and TO is a directory name, copy FROM
+into TO as a subdirectory.
 
 ```lisp
 (f-copy "path/to/file.txt" "new-file.txt")
@@ -703,7 +710,7 @@ RECURSIVE - Search for files and directories recursive.
 
 ### f-directories `(path &optional fn recursive)`
 
-Find all directories in PATH.  See ‘f-entries‘.
+Find all directories in PATH.  See ‘f-entries’.
 
 ```lisp
 (f-directories "path/to/dir")
@@ -714,7 +721,7 @@ Find all directories in PATH.  See ‘f-entries‘.
 
 ### f-files `(path &optional fn recursive)`
 
-Find all files in PATH.  See ‘f-entries‘.
+Find all files in PATH.  See ‘f-entries’.
 
 ```lisp
 (f-files "path/to/dir")

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-symlink](#f-symlink-source-path) `(source path)`
 * [f-move](#f-move-from-to) `(from to)`
 * [f-copy](#f-copy-from-to) `(from to)`
-* [f-copy-contenst](#f-copy-contents-from-to) `(from to)`
+* [f-copy-contents](#f-copy-contents-from-to) `(from to)`
 * [f-touch](#f-touch-path) `(path)`
 
 ### Predicates

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -53,7 +53,7 @@ Or you can just dump `f.el` in your load path somewhere.
 * [f-symlink](#f-symlink-source-path) `(source path)`
 * [f-move](#f-move-from-to) `(from to)`
 * [f-copy](#f-copy-from-to) `(from to)`
-* [f-copy-contenst](#f-copy-contents-from-to) `(from to)`
+* [f-copy-contents](#f-copy-contents-from-to) `(from to)`
 * [f-touch](#f-touch-path) `(path)`
 
 ### Predicates


### PR DESCRIPTION
Fix typo in README.md that I can't unsee now.