### PR TITLE
Add Github workflows for tests and docs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,3 +46,39 @@ jobs:
         run: cask install
         if: steps.cask-cache-executable.outputs.cache-hit != 'true'
       - run: make all
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: purcell/setup-emacs@master
+        with:
+          version: 28.1
+      - uses: actions/cache@v2
+        id: cache-cask-packages
+        with:
+          path: .cask
+          key: cache-cask-packages-000
+      - uses: actions/cache@v2
+        id:  cache-cask-executable
+        with:
+          path: ~/.cask
+          key: cache-cask-executable-000
+      - name: "Cask setup"
+        uses: cask/setup-cask@master
+        if: steps.cask-cache-executable.outputs.cache-hit != 'true'
+        with:
+          version: snapshot
+      - name: "Install Cask dependencies"
+        run: cask install
+        if: steps.cask-cache-executable.outputs.cache-hit != 'true'
+      # - run: cask exec emacs -Q --script bin/docs.el
+      - run: make docs
+      - name: "Commit README changes"
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: Update README
+          default_author: github_actions
+          add: README.md

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - 25.1
+          - 25.2
+          - 25.3
+          - 26.1
+          - 26.2
+          - 26.3
+          - 27.1
+          - 27.2
+          - 28.1
+          - snapshot
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+      - uses: actions/cache@v2
+        id: cache-cask-packages
+        with:
+          path: .cask
+          key: cache-cask-packages-000
+      - uses: actions/cache@v2
+        id:  cache-cask-executable
+        with:
+          path: ~/.cask
+          key: cache-cask-executable-000
+      - name: "Cask setup"
+        uses: cask/setup-cask@master
+        if: steps.cask-cache-executable.outputs.cache-hit != 'true'
+        with:
+          version: snapshot
+      - name: "Install Cask dependencies"
+        run: cask install
+        if: steps.cask-cache-executable.outputs.cache-hit != 'true'
+      - run: make all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-EMACS ?= emacs
-CASK ?= cask
+# -*- indent-tabs-mode: t -*-
+export EMACS ?= $(shell which emacs)
+CASK ?= $(shell which cask)
 
 all: test
 
@@ -16,7 +17,7 @@ docs:
 	${CASK} exec ${EMACS} -Q --script bin/docs.el
 
 compile:
-	${CASK} exec ${EMACS} -Q -batch -f batch-byte-compile f.el
+	${CASK} build
 
 clean-elc:
 	rm -f f.elc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# f.el [![Build Status](https://api.travis-ci.org/rejeep/f.el.png?branch=master)](http://travis-ci.org/rejeep/f.el) [![Coverage Status](https://img.shields.io/coveralls/rejeep/f.el.svg)](https://coveralls.io/r/rejeep/f.el)
+# f.el [![CI](https://github.com/rajeep/f.el/actions/workflows/workflow.yml/badge.svg)](https://github.com/rajeep/f.el/actions/workflows/workflow.yml) [![Coverage Status](https://img.shields.io/coveralls/rejeep/f.el.svg)](https://coveralls.io/r/rejeep/f.el)
 
 Much inspired by [@magnars](https://github.com/magnars)'s excellent
 [s.el](https://github.com/magnars/s.el) and

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -1,4 +1,4 @@
-# f.el [![Build Status](https://api.travis-ci.org/rejeep/f.el.png?branch=master)](http://travis-ci.org/rejeep/f.el) [![Coverage Status](https://img.shields.io/coveralls/rejeep/f.el.svg)](https://coveralls.io/r/rejeep/f.el)
+# f.el [![CI](https://github.com/rajeep/f.el/actions/workflows/workflow.yml/badge.svg)](https://github.com/rajeep/f.el/actions/workflows/workflow.yml) [![Coverage Status](https://img.shields.io/coveralls/rejeep/f.el.svg)](https://coveralls.io/r/rejeep/f.el)
 
 Much inspired by [@magnars](https://github.com/magnars)'s excellent
 [s.el](https://github.com/magnars/s.el) and

--- a/test/f-paths-test.el
+++ b/test/f-paths-test.el
@@ -390,18 +390,18 @@
 
 ;;;; f-uniquify-alist
 
-(ert-deftest f-uniquify/no-conflict ()
-  (should (equal (f-uniquify-alist '("/foo/bar" "/foo/baz" "/foo/quux")) '(("/foo/bar" . "bar") ("/foo/baz" . "baz") ("/foo/quux" . "quux")) )))
+(ert-deftest f-uniquify-alist/no-conflict ()
+  (should (equal (f-uniquify-alist '("/foo/bar" "/foo/baz" "/foo/quux")) '(("/foo/bar" . "bar") ("/foo/baz" . "baz") ("/foo/quux" . "quux")))))
 
 (ert-deftest f-uniquify-alist/single-conflict ()
-  (should (equal (f-uniquify-alist '("/foo/bar" "/www/bar" "/foo/quux")) '(("/foo/bar" . "foo/bar") ("/www/bar" . "www/bar") ("/foo/quux" . "quux")) )))
+  (should (equal (f-uniquify-alist '("/foo/bar" "/www/bar" "/foo/quux")) '(("/foo/bar" . "foo/bar") ("/www/bar" . "www/bar") ("/foo/quux" . "quux")))))
 
 (ert-deftest f-uniquify-alist/single-conflict-shared-subpath ()
   (should (equal (f-uniquify-alist '("/foo/bar" "/www/bar" "/www/bar/quux")) '(("/foo/bar" . "foo/bar") ("/www/bar" . "www/bar") ("/www/bar/quux" . "quux")))))
 
 (ert-deftest f-uniquify-alist/recursive-conflict ()
   (should (equal (f-uniquify-alist '("/foo/bar" "/foo/baz" "/home/www/bar" "/home/www/baz" "/var/foo" "/opt/foo/www/baz"))
-                 '(("/foo/bar" . "foo/bar") ("/home/www/bar" . "www/bar") ("/foo/baz" . "foo/baz") ("/home/www/baz" . "home/www/baz") ("/opt/foo/www/baz" . "foo/www/baz") ("/var/foo" . "foo")) )))
+                 '(("/foo/bar" . "foo/bar") ("/home/www/bar" . "www/bar") ("/foo/baz" . "foo/baz") ("/home/www/baz" . "home/www/baz") ("/opt/foo/www/baz" . "foo/www/baz") ("/var/foo" . "foo")))))
 
 (provide 'f-paths-test)
 

--- a/test/f-sandbox-test.el
+++ b/test/f-sandbox-test.el
@@ -179,7 +179,7 @@
 
 ;;;; f-copy
 
-(ert-deftest f-guard-test/f-copy/inside ()
+(ert-deftest f-guard-test/f-copy/f-expand/inside ()
   (with-playground
    (let ((path-foo (f-expand "foo" f-test/playground-path))
          (path-bar (f-expand "bar" f-test/playground-path)))


### PR DESCRIPTION
These commits add two new workflows to the repository:
- One that runs the tests with ert-runners
- One that automatically updates README.md

With this, we don’t need to use TravisCI anymore, and contributors
that want to edit the README only need to edit its template.