### PR TITLE
Recursive mkdir

### DIFF
--- a/f.el
+++ b/f.el
@@ -270,6 +270,23 @@ If APPEND is non-nil, append the DATA to the existing contents."
         (unless (f-directory? path)
           (f--destructive path (make-directory path)))))))
 
+(defun f-mkdir-recursive (&rest dirs)
+  "Recursively create each directory in DIRS."
+
+  (dolist (dir dirs)
+    (let (dirs-to-mkdir)
+
+      (f-traverse-upwards
+       (lambda (path)
+	 (let ((f-exists-p (f-exists? path)))
+	   (unless f-exists-p
+	     (push path dirs-to-mkdir))
+	   f-exists-p))
+       dir)
+
+      (dolist (dir-to-mkdir dirs-to-mkdir)
+	(f--destructive dir-to-make (f-mkdir dir-to-mkdir))))))
+
 (defun f-delete (path &optional force)
   "Delete PATH, which can be file or directory.
 


### PR DESCRIPTION
I was looking for a way to implement recursive `mkdir` (i.e., `mkdir -p`). Since the library does not have such a function out of the box, I would like to take a stab at it. 

I have called it `f-mkdir-recursive`. It uses `f-traverse-upwards` and tries to maintain an interface as similar to `f-mkdir` as possible. All suggestions about how to make the function more efficient are super welcome. 

Initial benchmarking (folder `~/exp` was already created before running these tests) shows it is faster than `make-directory`. I am sure this comes at a cost, but I am not able to tell what this cost is.

```
#+BEGIN_SRC emacs-lisp
(let ((path "~/exp/make-directory/sub"))
  (benchmark-run 10000
    (make-directory path t)))
#+END_SRC

#+RESULTS:
| 2.011198862 | 1 | 0.29728832399999305 |

#+BEGIN_SRC emacs-lisp
(let ((path "~/exp/f-mkdir-recursive/sub"))
  (benchmark-run 10000
    (f-mkdir-recursive path)))
#+END_SRC

#+RESULTS:
| 1.003087726 | 1 | 0.2717912070000068 |

#+BEGIN_SRC emacs-lisp
(let ((path "~/exp/md"))
  (benchmark-run 10000
    (make-directory path t)))
#+END_SRC

#+RESULTS:
| 1.751611431 | 1 | 0.26697017300000425 |

#+BEGIN_SRC emacs-lisp
(let ((path "~/exp/fmr"))
  (benchmark-run 10000
    (f-mkdir-recursive path)))
#+END_SRC

#+RESULTS:
| 0.6851341670000001 | 0 | 0.0 |
```