### PR TITLE
Require shortdoc.el for Emacs 28 only

### DIFF
--- a/f-shortdoc.el
+++ b/f-shortdoc.el
@@ -30,7 +30,8 @@
 ;;; Code:
 
 (when (version<= "28.1" emacs-version)
-  (require 'shortdoc)
+  (when (< emacs-major-version 29)
+    (require 'shortdoc))
 
   (define-short-documentation-group f
     "Paths"


### PR DESCRIPTION
Partially fixes #113 for Emacs 29+.
As from upstream's [98c910](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=98c9105f059085da8ebbbf4d50fc43abcb7a2d32), `define-short-documentation-group` doesn't need loading `shortdoc.el` anymore.