### PR TITLE
Add `f-presence`, `f-presence-directory`, `f-presence-file`, `f-presence-symlink`, and `f-presence-readable`

### DIFF
--- a/README.org
+++ b/README.org
@@ -84,6 +84,11 @@ Or you can just dump ~f.el~ in your load path somewhere.
     - [[#f-modification-time][f-modification-time]]
     - [[#f-access-time][f-access-time]]
   - [[#misc][Misc]]
+    - [[#f-presence][f-presence]]
+    - [[#f-presence-directory][f-presence-directory]]
+    - [[#f-presence-file][f-presence-file]]
+    - [[#f-presence-symlink][f-presence-symlink]]
+    - [[#f-presence-readable][f-presence-readable]]
     - [[#f-this-file][f-this-file]]
     - [[#f-path-separator][f-path-separator]]
     - [[#f-glob][f-glob]]
@@ -1019,6 +1024,100 @@ returned value, see ‘f--get-time’.
 #+end_src
 
 ** Misc
+*** f-presence
+#+begin_example
+(f-presence path)
+
+When PATH exists, return PATH, else nil.
+#+end_example
+
+Aliases:
+- ~f-present?~
+- ~f-present-p~
+
+#+begin_src emacs-lisp
+(f-presence "path/to/file.txt") ;; => "path/to/file.txt"
+(f-presence "path/to/nonexistent.txt") ;; => nil
+(f-presence "path/to/directory") ;; => "path/to/directory"
+(f-presence "path/to/nonexistent") ;; => nil
+(f-presence "path/to/symlink") ;; => "path/to/symlink"
+(f-presence "path/to/nonexistent_symlink") ;; => nil
+(f-presence nil) ;; => nil
+(f-presence "") ;; => nil
+#+end_src
+
+*** f-presence-directory
+#+begin_example
+(f-presence-directory path)
+
+When directory PATH exists, return PATH, else nil.
+#+end_example
+
+Aliases:
+- ~f-directory-present?~
+- ~f-directory-present-p~
+
+#+begin_src emacs-lisp
+(f-presence-directory "path/to/file.txt") ;; => nil
+(f-presence-directory "path/to/directory") ;; => "path/to/directory"
+(f-presence-directory "path/to/nonexistent") ;; => nil
+(f-presence-directory "path/to/symlink") ;; => nil
+#+end_src
+
+*** f-presence-file
+#+begin_example
+(f-presence-file path)
+
+When file PATH exists, return PATH, else nil.
+#+end_example
+
+Aliases:
+- ~f-file-present?~
+- ~f-file-present-p~
+
+#+begin_src emacs-lisp
+(f-presence-file "path/to/file.txt") ;; => "path/to/file.txt"
+(f-presence-file "path/to/nonexistent.txt") ;; => nil
+(f-presence-file "path/to/directory") ;; => nil
+(f-presence-file "path/to/symlink") ;; => nil
+#+end_src
+
+*** f-presence-symlink
+#+begin_example
+(f-presence-symlink path)
+
+When symlink PATH exists, return PATH, else nil.
+#+end_example
+
+Aliases:
+- ~f-symlink-present?~
+- ~f-symlink-present-p~
+
+#+begin_src emacs-lisp
+(f-presence-symlink "path/to/file.txt") ;; => nil
+(f-presence-symlink "path/to/directory") ;; => nil
+(f-presence-symlink "path/to/symlink") ;; => "path/to/symlink"
+(f-presence-symlink "path/to/nonexistent_symlink") ;; => nil
+#+end_src
+
+*** f-presence-readable
+#+begin_example
+(f-presence-readable path)
+
+When PATH is readable, return PATH, else nil.
+#+end_example
+
+Aliases:
+- ~f-readable-presence?~
+- ~f-readable-presence-p~
+
+#+begin_src emacs-lisp
+(f-presence-readable "path/to/readable.txt") ;; => "path/to/readable.txt"
+(f-presence-readable "path/to/unreadable.txt") ;; => nil
+(f-presence-readable "path/to/readable") ;; => "path/to/readable"
+(f-presence-readable "path/to/unreadable") ;; => nil
+#+end_src
+
 *** f-this-file
 #+begin_example
 (f-this-file)

--- a/README.org.tpl
+++ b/README.org.tpl
@@ -84,6 +84,11 @@ Or you can just dump ~f.el~ in your load path somewhere.
     - [[#f-modification-time][f-modification-time]]
     - [[#f-access-time][f-access-time]]
   - [[#misc][Misc]]
+    - [[#f-presence][f-presence]]
+    - [[#f-presence-directory][f-presence-directory]]
+    - [[#f-presence-file][f-presence-file]]
+    - [[#f-presence-symlink][f-presence-symlink]]
+    - [[#f-presence-readable][f-presence-readable]]
     - [[#f-this-file][f-this-file]]
     - [[#f-path-separator][f-path-separator]]
     - [[#f-glob][f-glob]]
@@ -911,6 +916,100 @@ Alias: ~f-same-time?~
 #+end_src
 
 ** Misc
+*** f-presence
+#+begin_example
+(f-presence path)
+
+{{f-presence}}
+#+end_example
+
+Aliases:
+- ~f-present?~
+- ~f-present-p~
+
+#+begin_src emacs-lisp
+(f-presence "path/to/file.txt") ;; => "path/to/file.txt"
+(f-presence "path/to/nonexistent.txt") ;; => nil
+(f-presence "path/to/directory") ;; => "path/to/directory"
+(f-presence "path/to/nonexistent") ;; => nil
+(f-presence "path/to/symlink") ;; => "path/to/symlink"
+(f-presence "path/to/nonexistent_symlink") ;; => nil
+(f-presence nil) ;; => nil
+(f-presence "") ;; => nil
+#+end_src
+
+*** f-presence-directory
+#+begin_example
+(f-presence-directory path)
+
+{{f-presence-directory}}
+#+end_example
+
+Aliases:
+- ~f-directory-present?~
+- ~f-directory-present-p~
+
+#+begin_src emacs-lisp
+(f-presence-directory "path/to/file.txt") ;; => nil
+(f-presence-directory "path/to/directory") ;; => "path/to/directory"
+(f-presence-directory "path/to/nonexistent") ;; => nil
+(f-presence-directory "path/to/symlink") ;; => nil
+#+end_src
+
+*** f-presence-file
+#+begin_example
+(f-presence-file path)
+
+{{f-presence-file}}
+#+end_example
+
+Aliases:
+- ~f-file-present?~
+- ~f-file-present-p~
+
+#+begin_src emacs-lisp
+(f-presence-file "path/to/file.txt") ;; => "path/to/file.txt"
+(f-presence-file "path/to/nonexistent.txt") ;; => nil
+(f-presence-file "path/to/directory") ;; => nil
+(f-presence-file "path/to/symlink") ;; => nil
+#+end_src
+
+*** f-presence-symlink
+#+begin_example
+(f-presence-symlink path)
+
+{{f-presence-symlink}}
+#+end_example
+
+Aliases:
+- ~f-symlink-present?~
+- ~f-symlink-present-p~
+
+#+begin_src emacs-lisp
+(f-presence-symlink "path/to/file.txt") ;; => nil
+(f-presence-symlink "path/to/directory") ;; => nil
+(f-presence-symlink "path/to/symlink") ;; => "path/to/symlink"
+(f-presence-symlink "path/to/nonexistent_symlink") ;; => nil
+#+end_src
+
+*** f-presence-readable
+#+begin_example
+(f-presence-readable path)
+
+{{f-presence-readable}}
+#+end_example
+
+Aliases:
+- ~f-readable-presence?~
+- ~f-readable-presence-p~
+
+#+begin_src emacs-lisp
+(f-presence-readable "path/to/readable.txt") ;; => "path/to/readable.txt"
+(f-presence-readable "path/to/unreadable.txt") ;; => nil
+(f-presence-readable "path/to/readable") ;; => "path/to/readable"
+(f-presence-readable "path/to/unreadable") ;; => nil
+#+end_src
+
 *** f-this-file
 #+begin_example
 (f-this-file)

--- a/f-shortdoc.el
+++ b/f-shortdoc.el
@@ -382,6 +382,64 @@
      :result 1672339999)
 
     "Misc"
+    (f-presence
+     :noeval (f-presence "path/to/file.txt")
+     :result "path/to/file.txt"
+     :noeval (f-presence "path/to/nonexistent.txt")
+     :result nil
+     :noeval (f-presence "path/to/directory")
+     :result "path/to/directory"
+     :noeval (f-presence "path/to/nonexistent")
+     :result nil
+     :noeval (f-presence "path/to/symlink")
+     :result "path/to/symlink"
+     :noeval (f-presence "path/to/nonexistent_symlink")
+     :result nil
+     :noeval (f-presence nil)
+     :result nil
+     :noeval (f-presence "")
+     :result nil)
+
+    (f-presence-directory
+     :noeval (f-presence-directory "path/to/file.txt")
+     :result nil
+     :noeval (f-presence-directory "path/to/directory")
+     :result "path/to/directory"
+     :noeval (f-presence-directory "path/to/nonexistent")
+     :result nil
+     :noeval (f-presence-directory "path/to/symlink")
+     :result nil)
+
+    (f-presence-file
+     :noeval (f-presence-file "path/to/file.txt")
+     :result "path/to/file.txt"
+     :noeval (f-presence-file "path/to/nonexistent.txt")
+     :result nil
+     :noeval (f-presence-file "path/to/directory")
+     :result nil
+     :noeval (f-presence-file "path/to/symlink")
+     :result nil)
+
+    (f-presence-symlink
+     :noeval (f-presence-symlink "path/to/file.txt")
+     :result nil
+     :noeval (f-presence-symlink "path/to/directory")
+     :result nil
+     :noeval (f-presence-symlink "path/to/symlink")
+     :result "path/to/symlink"
+     :noeval (f-presence-symlink "path/to/nonexistent_symlink")
+     :result nil)
+
+    (f-presence-readable
+     :noeval (f-presence-readable "path/to/readable.txt")
+     :result "path/to/readable.txt"
+     :noeval (f-presence-readable "path/to/unreadable.txt")
+     :result nil
+     :noeval (f-presence-readable "path/to/readable")
+     :result "path/to/readable"
+     :noeval (f-presence-readable "path/to/unreadable")
+     :result nil)
+
     (f-this-file
      :no-eval* (f-this-file))
 

--- a/f.el
+++ b/f.el
@@ -667,6 +667,41 @@ For more info on METHOD, see `f--date-compare'."
 
 ;;;; Misc
 
+(defun f-presence (path)
+  "When PATH exists, return PATH, else nil."
+  (when (f-exists-p path) path))
+
+(defalias 'f-present? #'f-presence)
+(defalias 'f-present-p #'f-presence)
+
+(defun f-presence-directory (path)
+  "When directory PATH exists, return PATH, else nil."
+  (when (f-directory-p path) path))
+
+(defalias 'f-directory-present? #'f-presence-directory)
+(defalias 'f-directory-present-p #'f-presence-directory)
+
+(defun f-presence-file (path)
+  "When file PATH exists, return PATH, else nil."
+  (when (f-file-p path) path))
+
+(defalias 'f-file-present? #'f-presence-file)
+(defalias 'f-file-present-p #'f-presence-file)
+
+(defun f-presence-symlink (path)
+  "When symlink PATH exists, return PATH, else nil."
+  (when (f-symlink-p path) path))
+
+(defalias 'f-symlink-present? #'f-presence-symlink)
+(defalias 'f-symlink-present-p #'f-presence-symlink)
+
+(defun f-presence-readable (path)
+  "When PATH is readable, return PATH, else nil."
+  (when (f-readable-p path) path))
+
+(defalias 'f-readable-presence? #'f-presence-readable)
+(defalias 'f-readable-presence-p #'f-presence-readable)
+
 (defun f-this-file ()
   "Return path to this file."
   (cond

--- a/test/f-misc-test.el
+++ b/test/f-misc-test.el
@@ -26,6 +26,96 @@
 ;;; Code:
 
 
+;;;; f-presence
+
+(ert-deftest f-presence/nonexistent-paths ()
+  (with-playground
+   (should
+    (equal
+     (mapcar 'f-presence ("nonexistent.txt" "nonexistent" "nonexistent_symlink" nil "")) '(nil nil nil nil nil)))))
+
+(ert-deftest f-presence/existent-paths ()
+  (with-playground
+   (f-touch "file.txt")
+   (f-mkdir "directory")
+   (f-symlink "symlink" "file.txt")
+   (should
+    (equal
+     (mapcar 'f-presence ("file.txt" "directory" "symlink")) '("file.txt" "directory" "symlink")))))
+
+
+;;;; f-presence-directory
+
+(ert-deftest f-presence-directory/non-directory-paths ()
+  (with-playground
+   (f-touch "file.txt")
+   (f-symlink "symlink" "file.txt")
+   (should
+    (equal
+     (mapcar 'f-presence-directory ("file.txt" "nonexistent" "symlink")) '(nil nil nil)))))
+
+(ert-deftest f-presence-directory/directory-paths ()
+  (with-playground
+   (f-mkdir "directory")
+   (should
+    (equal
+     (mapcar 'f-presence-directory ("directory")) '("directory")))))
+
+
+;;;; f-presence-file
+
+(ert-deftest f-presence-file/non-file-paths ()
+  (with-playground
+   (f-mkdir "directory")
+   (f-symlink "symlink" "directory")
+   (should
+    (equal
+     (mapcar 'f-presence-file ("nonexistent.txt" "directory" "symlink")) '(nil nil nil)))))
+
+(ert-deftest f-presence-file/file-paths ()
+  (with-playground
+   (f-touch "file.txt")
+   (should
+    (equal
+     (mapcar 'f-presence-file ("file.txt")) '("file.txt")))))
+
+
+;;;; f-presence-symlink
+
+(ert-deftest f-presence-symlink/non-symlink-paths ()
+  (with-playground
+   (f-touch "file.txt")
+   (f-mkdir "directory")
+   (should
+    (equal
+     (mapcar 'f-presence-symlink ("file.txt" "directory" "nonexistent_symlink")) '(nil nil nil)))))
+
+(ert-deftest f-presence-symlink/symlink-paths ()
+  (with-playground
+   (f-touch "file.txt")
+   (f-symlink "symlink" "file.txt")
+   (should
+    (equal
+     (mapcar 'f-presence-symlink ("symlink")) '("symlink")))))
+
+
+;;;; f-presence-readable
+
+(ert-deftest f-presence-readable/unreadable-paths ()
+  (with-playground
+   (should
+    (equal
+     (mapcar 'f-presence-readable ("unreadable.txt" "unreadable")) '(nil nil)))))
+
+(ert-deftest f-presence-readable/readable-paths ()
+  (with-playground
+   (f-touch "readable.txt")
+   (f-mkdir "readable")
+   (should
+    (equal
+     (mapcar 'f-presence-readable ("readable.txt" "readable")) '("readable.txt" "readable")))))
+
+
 ;;;; f-glob
 
 (ert-deftest f-glob-test/without-path ()


### PR DESCRIPTION
The same as the [previous pull request](https://github.com/rejeep/f.el/pull/118), but hopefully with everything rebased and merged properly:

Add functions to return `path` when `path` exists, is a file, is a directory, is a symlink, or is readable, similar to [`s-presence`](https://github.com/magnars/s.el#s-presence-s) from [Magnar's `s.el`](https://github.com/magnars/s.el).

This should be useful in situations such as `(cond)`, where you might want to see if a file, directory, symlink, etc. exists before returning it, all in one go.