### PR TITLE
Fix (f-shortdoc.el): changed keyword `:noeval` to `:no-eval`

### DIFF
--- a/f-shortdoc.el
+++ b/f-shortdoc.el
@@ -305,27 +305,27 @@
      :result nil)
 
     (f-older-p
-     :noeval (f-older-p "older-file.txt" "newer-file.txt")
+     :no-eval (f-older-p "older-file.txt" "newer-file.txt")
      :result t
-     :noeval (f-older-p "newer-file.txt" "older-file.txt")
+     :no-eval (f-older-p "newer-file.txt" "older-file.txt")
      :result nil
-     :noeval (f-older-p "same-time1.txt" "same-time2.txt")
+     :no-eval (f-older-p "same-time1.txt" "same-time2.txt")
      :result nil)
 
     (f-newer-p
-     :noeval (f-newer-p "newer-file.txt" "older-file.txt")
+     :no-eval (f-newer-p "newer-file.txt" "older-file.txt")
      :result t
-     :noeval (f-newer-p "older-file.txt" "newer-file.txt")
+     :no-eval (f-newer-p "older-file.txt" "newer-file.txt")
      :result nil
-     :noeval (f-newer-p "same-time1.txt" "same-time2.txt")
+     :no-eval (f-newer-p "same-time1.txt" "same-time2.txt")
      :result nil)
 
     (f-same-time-p
-     :noeval (f-same-time-p "same-time1.txt" "same-time2.txt")
+     :no-eval (f-same-time-p "same-time1.txt" "same-time2.txt")
      :result t
-     :noeval (f-same-time-p "newer-file.txt" "older-file.txt")
+     :no-eval (f-same-time-p "newer-file.txt" "older-file.txt")
      :result nil
-     :noeval (f-same-time-p "older-file.txt" "newer-file.txt")
+     :no-eval (f-same-time-p "older-file.txt" "newer-file.txt")
      :result nil)
 
     "Stats"


### PR DESCRIPTION
- In the body of `define-short-documentation-group` function call, some of the keywords (`:noeval`) will cause an error in `shortdoc--check` where the valid keywords has been enforced in the newer Emacs release (30.0.50).

  - A checker was added in Emacs upstream (`shortdoc--check`):  https://github.com/emacs-mirror/emacs/commit/ddfba511c190e5bb44e44a50aef5ab8c08e3d798

- Also I noticed that, some of the `GROUP` definitions in `define-short-documentation-group` is mixing these keywords up (`:noeval` and `:no-eval`). So this PR is to simply fix this.