### PR TITLE
fix: fix f-ancestor-of-p bug

### DIFF
--- a/f.el
+++ b/f.el
@@ -447,8 +447,11 @@ The extension, in a file name, is the part that follows the last
 (defun f-ancestor-of-p (path-a path-b)
   "Return t if PATH-A is ancestor of PATH-B."
   (unless (f-same-p path-a path-b)
-    (string-prefix-p (f-full path-a)
-                     (f-full path-b))))
+    (cond ((string-suffix-p (f-path-separator) path-a)
+           (string-prefix-p (f-full path-a)
+                            (f-full path-b)))
+          (t (string-prefix-p (f-full (concat path-a (f-path-separator)))
+                              (f-full path-b))))))
 
 (defalias 'f-ancestor-of? 'f-ancestor-of-p)
 

--- a/test/f-predicates-test.el
+++ b/test/f-predicates-test.el
@@ -339,6 +339,7 @@
    (should (equal t (f-ancestor-of-p "foo/bar" "foo/bar/baz")))
    (should (equal t (f-ancestor-of-p "foo/bar" "foo/bar/baz/qux")))
    (should (equal t (f-ancestor-of-p "foo/bar/baz" "foo/bar/baz/qux")))
+   (should (equal t (f-ancestor-of-p "foo/bar/" "foo/bar/baz/qux")))
    (should (equal t (f-ancestor-of-p (f-root) (f-expand (car (f-directories (f-root))) (f-root)))))))
 
 (ert-deftest f-ancestor-of-p-test/is-not-ancestor ()
@@ -350,6 +351,7 @@
    (should-not (f-ancestor-of-p "foo/bar/baz" "foo/bar"))
    (should-not (f-ancestor-of-p "foo/bar/baz/qux" "foo/bar"))
    (should-not (f-ancestor-of-p "foo/bar/baz/qux" "foo/bar/baz"))
+   (should-not (f-ancestor-of-p "foo" "foobar/baz"))
    (should-not (f-ancestor-of-p (f-expand (car (f-directories (f-root))) (f-root)) (f-root)))))
 
 (ert-deftest f-ancestor-of-p-test/is-same ()


### PR DESCRIPTION
--master

~/abc or ~/abc/ is the ancestor of ~/abc/def

whereas

~/ab is not the ancestor of ~/abc/def